### PR TITLE
Switch out date concatenation(+) with DATE_ADD

### DIFF
--- a/macros/dbt_utils/cross_db_utils/dateadd.sql
+++ b/macros/dbt_utils/cross_db_utils/dateadd.sql
@@ -1,3 +1,3 @@
 {% macro presto__dateadd(datepart, interval, from_date_or_timestamp) -%}
-    {{ from_date_or_timestamp }} + interval '{{ interval }}' {{ datepart }}
+    DATE_ADD('{{datepart}}', {{ interval }}, {{ from_date_or_timestamp }})
 {%- endmacro %}


### PR DESCRIPTION
Switch out date concatenation(+) with DATE_ADD function. Functionality should be the same but won't error when using window functions. This was caught after using dbt_utils.date_spine.